### PR TITLE
[ADD] : 모임 추가,수정,삭제시 태그 테이블에 반영되도록 수정

### DIFF
--- a/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/club/service/ClubService.java
+++ b/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/club/service/ClubService.java
@@ -27,6 +27,7 @@ import webProject.togetherPartyTonight.domain.member.repository.MemberRepository
 import webProject.togetherPartyTonight.domain.review.dto.response.GetReviewDetailResponseDto;
 import webProject.togetherPartyTonight.domain.review.entity.Review;
 import webProject.togetherPartyTonight.domain.review.repository.ReviewRepository;
+import webProject.togetherPartyTonight.domain.search.repository.TagRepository;
 import webProject.togetherPartyTonight.global.error.ErrorCode;
 import webProject.togetherPartyTonight.global.util.ClubUtils;
 import webProject.togetherPartyTonight.infra.S3.S3Service;
@@ -51,6 +52,8 @@ public class ClubService {
 
     private final S3Service s3Service;
 
+    private final TagRepository tagRepository;
+
     private final String directory = "club/";
     private final ClubUtils clubUtils;
 
@@ -71,6 +74,9 @@ public class ClubService {
         Club club = clubRequest.toClub(member, point, url);
 
         clubRepository.save(club);
+
+        addTagCount(clubUtils.splitTags(club.getClubTags()));
+
 
     }
 
@@ -96,6 +102,9 @@ public class ClubService {
 
         clubMemberRepository.deleteByClubClubId(clubId);
         clubSignupRepository.deleteByClubClubId(clubId);
+
+        deleteTagCount(clubUtils.splitTags(club.getClubTags()));
+
         }
 
     @Transactional
@@ -104,7 +113,9 @@ public class ClubService {
         Club club = clubRepository.findByClubIdAndMasterId(clubId, member.getId())
                 .orElseThrow(()-> new ClubException(ClubErrorCode.INVALID_CLUB_ID));
        checkAuthority(club, member);
-        compareChange(clubRequest, club, image, member);
+       deleteTagCount(clubUtils.splitTags(club.getClubTags()));
+       addTagCount(clubUtils.splitTags(clubRequest.getClubTags()));
+       compareChange(clubRequest, club, image, member);
 
     }
 
@@ -192,6 +203,18 @@ public class ClubService {
         }
         else {
             return (float)sum /div;
+        }
+    }
+
+    public void addTagCount (List<String> tags) {
+        for (String t : tags) {
+            tagRepository.saveTagNameAndTagCount(t);
+        }
+    }
+
+    public void deleteTagCount (List<String> tags) {
+        for (String t : tags) {
+            tagRepository.deleteTagCount(t);
         }
     }
 

--- a/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/dto/tagSaveDto.java
+++ b/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/dto/tagSaveDto.java
@@ -1,0 +1,9 @@
+package webProject.togetherPartyTonight.domain.search.dto;
+
+import lombok.Data;
+
+@Data
+public class tagSaveDto {
+    private String tagName;
+    private Long tagCount;
+}

--- a/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/entity/Tag.java
+++ b/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/entity/Tag.java
@@ -12,14 +12,16 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "tag")
+@Table(name = "tag", indexes = {
+        @Index(name = "tag_count_idx", columnList = "tag_count")
+})
 public class Tag extends BaseEntity {
     @Id
     @Column(name = "tag_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tagId;
 
-    @Column(name="tag_name", nullable = false)
+    @Column(name="tag_name", nullable = false, unique = true)
     private String tagName;
 
     @Column(name="tag_count", nullable = false)

--- a/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/repository/TagRepository.java
+++ b/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/search/repository/TagRepository.java
@@ -1,6 +1,9 @@
 package webProject.togetherPartyTonight.domain.search.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import webProject.togetherPartyTonight.domain.search.entity.Tag;
 
@@ -10,4 +13,14 @@ import java.util.List;
 public interface TagRepository extends JpaRepository<Tag,Long> {
 
     List<Tag> findTop12ByOrderByTagCountDesc ();
+
+    @Modifying
+    @Query(nativeQuery = true, value = "INSERT INTO tag (created_date, modified_date, tag_name, tag_count) " +
+            "VALUES (NOW(), NOW(), :tagName, 1) " +
+            "ON DUPLICATE KEY UPDATE tag_count = tag_count + 1;")
+    void saveTagNameAndTagCount(@Param(value = "tagName")String tagName);
+
+    @Modifying
+    @Query(nativeQuery = true, value = "UPDATE tag SET tag_count= tag_count -1 WHERE tag_name = :tagName")
+    void deleteTagCount(@Param(value = "tagName")String tagName);
 }


### PR DESCRIPTION
## 작업사항
- 모임 추가,삭제,수정시 태그 count가 업데이트되도록 수정
- 태그 테이블 인덱스 설정

## 비고
- 

## Github 이슈
- 

## 작업일자
- 2023.08.01

<br>
