### PR TITLE
[BUGFIX] :  정산 결제에서 결제내역 멤버와 같아도 에러가 나오는 현상 수정

### DIFF
--- a/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/billing/service/BillingService.java
+++ b/togetherPartyTonight/src/main/java/webProject/togetherPartyTonight/domain/billing/service/BillingService.java
@@ -184,7 +184,7 @@ public class BillingService {
                     throw new BillingException(BILLING_HISTORY_NOT_FOUNT);
                 });
 
-        if (isBillingHistoryMemberSame(member, billingHistory)) {
+        if (!isBillingHistoryMemberSame(member, billingHistory)) {
             log.error("[BillingService] processPayment billingHistory member id different memberId: {}, billingHistoryId: {}", member.getId(), billingPaymentRequestDto.getBillingHistoryId());
             throw new BillingException(BILLING_HISTORY_MEMBER_DIFFERENT);
         }


### PR DESCRIPTION
## 작업사항
- 정산 결제에서 결제내역 멤버와 같아도 에러가 나오는 현상 수정

## 비고
## Github 이슈
## 작업일자
- 2023.08.07
